### PR TITLE
Use ES6 modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.8"
+  - "8"

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-var util = require('util');
-var EventEmitter = require('events').EventEmitter;
+import util from 'util';
+import { EventEmitter } from 'events';
 
 function HoneyBadger() {
   EventEmitter.call(this);
@@ -58,4 +58,4 @@ HoneyBadger.prototype.eatLarvae = function() {
  * Unleash the honey badger.
  * @type {HoneyBadger}
  */
-exports = module.exports = new HoneyBadger();
+export default new HoneyBadger();

--- a/package.json
+++ b/package.json
@@ -17,10 +17,17 @@
     "url": "https://github.com/tschaub/thehoneybadger/issues"
   },
   "devDependencies": {
-    "mocha": "1.12.0",
-    "chai": "1.7.2"
+    "babel-preset-es2015": "^6.24.1",
+    "babel-register": "^6.26.0",
+    "chai": "4.1.2",
+    "mocha": "4.0.1"
   },
   "scripts": {
-    "test": "mocha spec.js --reporter spec"
+    "test": "mocha --require babel-register spec.js --reporter spec"
+  },
+  "babel": {
+    "presets": [
+      "es2015"
+    ]
   }
 }

--- a/spec.js
+++ b/spec.js
@@ -1,5 +1,5 @@
-var hb = require('./index');
-var expect = require('chai').expect;
+import hb from './index';
+import { expect } from 'chai';
 
 describe('the honey badger', function() {
 


### PR DESCRIPTION
I still love this project for educational purposes in my lectures. Now that I've shown my students how ES6 modules work, I don't want to confuse them with CommonJS as another way.

This pull request makes it so the project uses ES6 modules with `import` and `export` instead of CommonJS with `require` and `module.exports`.